### PR TITLE
Interfaces for Expect score computation.

### DIFF
--- a/src/main/java/org/phenoscape/owl/sim/ComparisonScore.java
+++ b/src/main/java/org/phenoscape/owl/sim/ComparisonScore.java
@@ -1,0 +1,13 @@
+package org.phenoscape.owl.sim;
+
+public interface ComparisonScore<ID> {
+
+	public ID id();
+
+	public double similarity();
+
+	public ID queryProfile();
+
+	public ID corpusProfile();
+
+}

--- a/src/main/java/org/phenoscape/owl/sim/ExpectScoreComputation.java
+++ b/src/main/java/org/phenoscape/owl/sim/ExpectScoreComputation.java
@@ -1,0 +1,10 @@
+package org.phenoscape.owl.sim;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface ExpectScoreComputation<ID> {
+
+	public Map<ID, Double> computeExpectScores(Collection<ComparisonScore<ID>> scores, Map<ID, Integer> corpusProfileSizes, Map<ID, Integer> queryProfileSizes);
+
+}


### PR DESCRIPTION
These are possible interfaces for interaction between the Phenoscape KB build and the Expect score computation. The compute-expect project will need to provide an implementation of `ExpectScoreComputation`.
